### PR TITLE
[DEVOPS-305] Set key vault list retrieval to fail only after 5 failed attempts

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -36,21 +36,41 @@ runs:
         REPOSITORY_NAME="${{ inputs.repositoryName }}"
         ENV_KEYVAULT_NAME="${{ inputs.environmentKeyVault }}"
 
-        DARKGRAY='\e[38;5;232m'
-        RED='\e[0;31m'
+        DARKGRAY="\033[38;5;232m"
+        RED="\033[0;31m"
+        YELLOW="\033[0;33m"
+        NC="\033[0m" # No Color
 
-        # Check if searching for key vaults by repository name or otherwise, if key vault name argument is given
+        # # If ENV_KEYVAULT_NAME is empty, search for key vault using tags
         if [ -z "${ENV_KEYVAULT_NAME}" ]; then
             # Search for key vault using tags
-            echo -e "${DARKGRAY}Searching for key vault with tags: \"repository-name=${REPOSITORY_NAME};environment=${ENVIRONMENT}\""
-            KEYVAULT_NAME=$(az keyvault list --query "[?tags.\"repository-name\" == '${REPOSITORY_NAME}' && tags.environment == '${ENVIRONMENT}'].name" --output tsv)
+            echo -e "${DARKGRAY}Searching for key vault with tags: \"repository-name=${REPOSITORY_NAME};environment=${ENVIRONMENT}\"${NC}"
 
-            # Check if key vault name is empty
-            if [ -z "${KEYVAULT_NAME}" ]; then
-                echo -e "${RED}Key vault name cannot be found. Please confirm this repository's key vaults are tagged correctly."
-                exit 1
-            fi
+            # Initialize a counter
+            COUNTER=1
+
+            # Try the command up to 5 times
+            while [[ "${COUNTER}" -lt 6 ]]; do
+                # Break loop if command is successful
+                if KEYVAULT_NAME=$(az keyvault list --query "[?tags.\"repository-name\" == '${REPOSITORY_NAME}' && tags.environment == '${ENVIRONMENT}'].name" --output tsv); then
+                    break
+                fi
+
+                # Display retry attempt and increment the COUNTER
+                echo -e "${YELLOW}Retrieval of the key vault failed on attempt ${COUNTER} of 5. Waiting 5 seconds before trying again.${NC}"
+                COUNTER=$((COUNTER+1))
+
+                # Exit with error after 5 failed attempts
+                if [[ "${COUNTER}" -eq 6 ]]; then
+                    echo -e "${RED}Failed to list key vaults after 5 attempts. Please confirm this repository's key vaults are tagged correctly.${NC}"
+                    exit 1
+                fi
+
+                # Pause before next attempt
+                sleep 5
+            done
         else
+            # If ENV_KEYVAULT_NAME is not empty, use it as the key vault name
             KEYVAULT_NAME="${ENV_KEYVAULT_NAME}"
         fi
 
@@ -59,7 +79,7 @@ runs:
 
         # Check if key vault exists
         if ! echo "${KEYVAULT}" | grep -Eq "\w"; then
-            echo -e "${RED}Invalid value provided for 'KeyVaultName'. Please confirm a Key Vault exists under the name specified. Value provided: ${KEYVAULT_NAME}"
+            echo -e "${RED}Invalid value provided for 'KeyVaultName'. Please confirm a Key Vault exists under the name specified. Value provided: ${NC}${KEYVAULT_NAME}"
             exit 1
         fi
         KEYVAULT_NAME=${KEYVAULT_NAME// /}


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-305" title="DEVOPS-305" target="_blank">DEVOPS-305</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Resolve timeout failures in generate build args/envs in GitHub actions workflows</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://amuniversal.atlassian.net/images/icons/issuetypes/story.png" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- There has been an issue with the `az keyvault list` command failing unexpectedly. To prevent this issue from happening in the future, the key vault list retrieval command now only fails after 5 failed attempts to pull them down.

Error: 
[Merge pull request #2359 from Andrews-McMeel-Universal/dependabot/npm… #778](https://github.com/Andrews-McMeel-Universal/puzzle-society_ui/actions/runs/6817996155/job/18542687422)
<img width="824" alt="image" href="https://github.com/Andrews-McMeel-Universal/puzzle-society_ui/actions/runs/6817996155/job/18542687422" src="https://github.com/Andrews-McMeel-Universal/get-envs/assets/111298136/2befaa52-c52f-4ce6-8ac0-76452082ee20">

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-305
