### PR TITLE
[DEVOPS-733] Enable caching when retrieving environment variables

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -34,7 +34,6 @@ inputs:
   envEncryptionSecret:
     required: false
     description: "Secret used to encrypt/decrypt the .env file"
-    default: ${{ secrets.ENV_ENCRYPTION_SECRET }}
 
 branding:
   color: purple

--- a/action.yaml
+++ b/action.yaml
@@ -154,11 +154,10 @@ runs:
                 echo 'environmentVariables<<EOF' >> $GITHUB_OUTPUT
                 echo "${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
                 echo 'EOF' >> $GITHUB_OUTPUT
-                echo "Environment variables have been added to 'environmentVariables' output"
             else
                 echo "environmentVariables=${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
-                echo "Environment variables have been added to 'environmentVariables' output"
             fi
+            echo "Environment variables have been added to 'environmentVariables' output"
         fi
 
     - name: Decrypt cached .env file
@@ -175,10 +174,11 @@ runs:
         ENV_VAR_SEP="${{ inputs.environmentVariableSeparator }}"
 
         if [[ -z "${CONTENT_TYPES}" ]] || [[ "${CONTENT_TYPES}" == *"Env"* ]]; then
+            ENVIRONMENT_VARIABLES=$(sed ':a;N;$!ba;s/\n\([^\n]\)/ \1/g' .env)
             if [[ "${ENV_VAR_SEP}" != " " ]]; then
                 echo 'environmentVariables<<EOF' >> $GITHUB_OUTPUT
-                sed ':a;N;$!ba;s/\n\([^\n]\)/ \1/g' .env >> $GITHUB_OUTPUT
-                echo -e '\nEOF' >> $GITHUB_OUTPUT
+                echo "${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
+                echo 'EOF' >> $GITHUB_OUTPUT
             else
                 ENVIRONMENT_VARIABLES=$(sed ":a;N;\$!ba;s/\n\([^\n]\)/${ENV_VAR_SEP}\1/g" .env)
                 echo "environmentVariables=${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT

--- a/action.yaml
+++ b/action.yaml
@@ -58,7 +58,7 @@ runs:
         creds: "${{ inputs.azurecredentials }}"
 
     - name: Retrieve key vault name
-      if: ! inputs.environmentKeyVault && (steps.cache-envs.outputs.cache-hit != 'true' || (steps.cache-envs.outputs.cache-hit == 'true' && contains(inputs.contentTypes, 'BuildArg')))
+      if: (!inputs.environmentKeyVault) && (steps.cache-envs.outputs.cache-hit != 'true' || (steps.cache-envs.outputs.cache-hit == 'true' && contains(inputs.contentTypes, 'BuildArg')))
       id: kv-name
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -176,12 +176,12 @@ runs:
         if [[ -z "${CONTENT_TYPES}" ]] || [[ "${CONTENT_TYPES}" == *"Env"* ]]; then
             if [[ "${ENV_VAR_SEP}" != " " ]]; then
                 echo 'environmentVariables<<EOF' >> $GITHUB_OUTPUT
-                cat .env | tr '\n' ' ' >> $GITHUB_OUTPUT
+                sed ':a;N;$!ba;s/\n\([^\n]\)/ \1/g' .env >> $GITHUB_OUTPUT
                 echo -e '\nEOF' >> $GITHUB_OUTPUT
             else
-                ENVIRONMENT_VARIABLES=$(cat .env | tr '\n' "${ENV_VAR_SEP}")
+                ENVIRONMENT_VARIABLES=$(sed ':a;N;$!ba;s/\n\([^\n]\)/${ENV_VAR_SEP}\1/g' .env")
+                echo "environmentVariables=${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
             fi
-            echo "environmentVariables=${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
             echo "Environment variables have been added to 'environmentVariables' output"
         fi
         if [[ "${CONTENT_TYPES}" == *"BuildArg"* ]]; then

--- a/action.yaml
+++ b/action.yaml
@@ -27,6 +27,14 @@ inputs:
     required: false
     description: "Separator for environment variables"
     default: " "
+  enableCaching:
+    required: false
+    description: "Enable caching of the .env file"
+    default: "true"
+  envEncryptionSecret:
+    required: false
+    description: "Secret used to encrypt/decrypt the .env file"
+    default: ${{ secrets.ENV_ENCRYPTION_SECRET }}
 
 branding:
   color: purple
@@ -39,12 +47,23 @@ runs:
       run: git config --global core.autocrlf false
       shell: bash
 
+    - name: Cache environment variables
+      id: cache-envs
+      if: ${{ inputs.enableCaching == 'true' }}
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ github.workspace }}/.env.gpg
+        key: env-${{ github.sha }}
+
     - name: Login via Az module
+      if: steps.cache-envs.outputs.cache-hit != 'true'
       uses: azure/login@v2
       with:
         creds: "${{ inputs.azurecredentials }}"
 
     - name: Generate .env file from Azure Key Vaults
+      if: steps.cache-envs.outputs.cache-hit != 'true'
       id: get-envs
       shell: bash
       run: |
@@ -143,6 +162,35 @@ runs:
             fi
         fi
 
+    - name: Decrypt cached .env file
+      if: steps.cache-envs.outputs.cache-hit == 'true'
+      shell: sh
+      run: |
+        gpg --decrypt --batch --yes --passphrase "${{ inputs.envEncryptionSecret }}" -o .env .env.gpg
+
+    - name: Set outputs
+      if: steps.cache-envs.outputs.cache-hit == 'true'
+      shell: sh
+      run: |
+        CONTENT_TYPES="${{ inputs.contentTypes }}"
+        ENV_VAR_SEP="${{ inputs.environmentVariableSeparator }}"
+        if [[ -z "${CONTENT_TYPES}" ]] || [[ "${CONTENT_TYPES}" == *"Env"* ]]; then
+            if [[ "${ENV_VAR_SEP}" != " " ]]; then
+                echo 'environmentVariables<<EOF' >> $GITHUB_OUTPUT
+                cat .env | tr '\n' ' ' >> $GITHUB_OUTPUT
+                echo -e '\nEOF' >> $GITHUB_OUTPUT
+            else
+                ENVIRONMENT_VARIABLES=$(cat .env | tr '\n' "${ENV_VAR_SEP}")
+            fi
+            echo "environmentVariables=${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
+            echo "Environment variables have been added to 'environmentVariables' output"
+        fi
+        if [[ "${CONTENT_TYPES}" == *"BuildArg"* ]]; then
+            BUILD_ARGUMENTS=$(sed ':a;N;$!ba;s/\n\([^\n]\)/ --build-arg \1/g; s/^/--build-arg /' .env)
+            echo "buildArguments=${BUILD_ARGUMENTS}" >> $GITHUB_OUTPUT
+            echo "Build arguments have been added to 'buildArguments' output"
+        fi
+
     - name: Source secrets file
       if: ${{ inputs.setBuildArguments != 'true' }}
       shell: sh
@@ -155,6 +203,12 @@ runs:
             fi
             echo "$envVar" >> $GITHUB_ENV
         done < .env
+
+    - name: Encrypt .env file for caching
+      if: steps.cache-envs.outputs.cache-hit != 'true'
+      shell: sh
+      run: |
+        gpg --symmetric --batch --yes --passphrase "${{ inputs.envEncryptionSecret }}" -o .env.gpg .env
 
 outputs:
   environmentVariables:

--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,7 @@ runs:
         key: env-${{ github.sha }}
 
     - name: Login via Az module
-      if: steps.cache-envs.outputs.cache-hit != 'true'
+      if: steps.cache-envs.outputs.cache-hit != 'true' || (steps.cache-envs.outputs.cache-hit == 'true' && contains(inputs.contentTypes, 'BuildArg'))
       uses: azure/login@v2
       with:
         creds: "${{ inputs.azurecredentials }}"

--- a/action.yaml
+++ b/action.yaml
@@ -131,7 +131,10 @@ runs:
           fi
         done
         SECRETS=("${SECRET_LIST[@]}")
+        echo "Total secrets found: ${#SECRETS[@]}"
 
+        BUILD_ARGUMENTS=""
+        ENVIRONMENT_VARIABLES=""
         echo "Retrieving secrets for key vault: ${KEYVAULT_NAME}"
         if echo "${SECRETS[*]}" | grep -E "\w" > /dev/null; then
             for SECRET in "${SECRETS[@]}"; do
@@ -232,7 +235,9 @@ runs:
           fi
         done
         SECRETS=("${SECRET_LIST[@]}")
+        echo "Total build argument secrets found: ${#SECRETS[@]}"
 
+        BUILD_ARGUMENTS=""
         echo "Retrieving build arguments for key vault: ${KEYVAULT_NAME}"
         if echo "${SECRETS[*]}" | grep -E "\w" > /dev/null; then
             for SECRET in "${SECRETS[@]}"; do

--- a/action.yaml
+++ b/action.yaml
@@ -222,10 +222,17 @@ runs:
 
         if [[ -z "${CONTENT_TYPES}" ]] || [[ "${CONTENT_TYPES}" == *"Env"* ]]; then
             if [[ "${ENV_VAR_SEP}" != " " ]]; then
-                ENVIRONMENT_VARIABLES=$(sed ":a;N;\$!ba;s|\n\([^\n]\)|${ENV_VAR_SEP}\1|g" .env)
-                echo 'environmentVariables<<EOF' >> $GITHUB_OUTPUT
-                echo "${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
-                echo 'EOF' >> $GITHUB_OUTPUT
+                ENVIRONMENT_VARIABLES=$(
+                  awk -v sep="$ENV_VAR_SEP" '
+                    NR==1 { printf "%s", $0; next }
+                    $0=="" { printf "\n"; next }
+                    { printf "%s%s", sep, $0 }
+                    END { printf "" }
+                  ' .env
+                )
+                echo 'environmentVariables<<EOF' >> "$GITHUB_OUTPUT"
+                printf '%s\n' "$ENVIRONMENT_VARIABLES" >> "$GITHUB_OUTPUT"
+                echo 'EOF' >> "$GITHUB_OUTPUT"
             else
                 ENVIRONMENT_VARIABLES=$(cat .env)
                 echo "environmentVariables=${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT

--- a/action.yaml
+++ b/action.yaml
@@ -42,10 +42,6 @@ branding:
 runs:
   using: "composite"
   steps:
-    - name: Normalize Git config
-      run: git config --global core.autocrlf false
-      shell: bash
-
     - name: Cache environment variables
       id: cache-envs
       if: ${{ inputs.enableCaching == 'true' }}
@@ -61,27 +57,37 @@ runs:
       with:
         creds: "${{ inputs.azurecredentials }}"
 
-    - name: Generate .env file from Azure Key Vaults
-      if: steps.cache-envs.outputs.cache-hit != 'true'
-      id: get-envs
+    - name: Retrieve key vault name
+      if: inputs.environmentKeyVault != '' && (steps.cache-envs.outputs.cache-hit != 'true' || (steps.cache-envs.outputs.cache-hit == 'true' && contains(inputs.contentTypes, 'BuildArg')))
+      id: kv-name
       shell: bash
       run: |
-        ENVIRONMENT="${{ inputs.environment }}"
-        REPOSITORY_NAME="${{ inputs.repositoryName }}"
-        ENV_KEYVAULT_NAME="${{ inputs.environmentKeyVault }}"
-        CONTENT_TYPES="${{ inputs.contentTypes }}"
+        set -euo pipefail
 
-        # If ENV_KEYVAULT_NAME is empty, search for key vault using tags
-        if [ -n "${ENV_KEYVAULT_NAME}" ]; then
-            # If ENV_KEYVAULT_NAME is not empty, use it as the key vault name
-            KEYVAULT_NAME="${ENV_KEYVAULT_NAME}"
-        else
-            # Search for key vault using tags
-            echo -e "Searching for key vault with tags: \"repository-name=${REPOSITORY_NAME};environment=${ENVIRONMENT}\""
-            KEYVAULT_NAME=$(az keyvault list --query "[?tags.\"repository-name\" == '${REPOSITORY_NAME}' && tags.environment == '${ENVIRONMENT}'].name" --output tsv)
+        REPOSITORY_NAME="${{ inputs.repositoryName }}"
+        ENVIRONMENT="${{ inputs.environment }}"
+
+        echo -e "Searching for key vault with tags: \"repository-name=${REPOSITORY_NAME};environment=${ENVIRONMENT}\""
+        KEYVAULT_NAME=$(az keyvault list --query "[?tags.\"repository-name\" == '${REPOSITORY_NAME}' && tags.environment == '${ENVIRONMENT}'].name" --output tsv)
+
+        if [ -z "${KEYVAULT_NAME}" ]; then
+            echo "No Key Vault found with the specified tags. Please confirm a Key Vault exists with the correct tags."
+            exit 1
         fi
 
+        echo "Found Key Vault: ${KEYVAULT_NAME}"
+        echo "keyVaultName=${KEYVAULT_NAME}" >> $GITHUB_OUTPUT
+
+    - name: Check if key vault exists
+      if: steps.cache-envs.outputs.cache-hit != 'true' || (steps.cache-envs.outputs.cache-hit == 'true' && contains(inputs.contentTypes, 'BuildArg'))
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        KEYVAULT_NAME="${{ steps.kv-name.outputs.keyVaultName || inputs.environmentKeyVault }}"
+
         # Get key vault object
+        echo "Verifying Key Vault exists: ${KEYVAULT_NAME}"
         KEYVAULT_NAME=${KEYVAULT_NAME// /}
         KEYVAULT=$(az keyvault list --query "[?name == '${KEYVAULT_NAME}']" )
 
@@ -90,6 +96,16 @@ runs:
             echo -e "Invalid value provided for 'KeyVaultName'. Please confirm a Key Vault exists under the name specified. Value provided: ${KEYVAULT_NAME}"
             exit 1
         fi
+
+    - name: Pull secrets from Key Vault
+      if: steps.cache-envs.outputs.cache-hit != 'true'
+      id: get-envs
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        CONTENT_TYPES="${{ inputs.contentTypes }}"
+        KEYVAULT_NAME="${{ steps.kv-name.outputs.keyVaultName }}"
 
         # Set secrets list
         echo "Retrieving list of secrets for key vault: ${KEYVAULT_NAME}"
@@ -116,7 +132,6 @@ runs:
         done
         SECRETS=("${SECRET_LIST[@]}")
 
-        # Loop through secrets and add them to .env file
         echo "Retrieving secrets for key vault: ${KEYVAULT_NAME}"
         if echo "${SECRETS[*]}" | grep -E "\w" > /dev/null; then
             for SECRET in "${SECRETS[@]}"; do
@@ -128,6 +143,11 @@ runs:
 
                 # Get secret value
                 SECRET_VALUE=$(az keyvault secret show --vault-name "${KEYVAULT_NAME}" -n "${SECRET}" --output tsv --query "value")
+
+                # Mask secret value in logs
+                if [[ "$SECRET_NAME" =~ (SECRET|TOKEN|KEY|PASS|CONNECTION_STRING) ]]; then
+                    echo "::add-mask::$SECRET_VALUE"
+                fi
 
                 # Get secret content type
                 SECRET_CONTENT_TYPE=$(az keyvault secret show --vault-name "${KEYVAULT_NAME}" -n "${SECRET}" --output tsv --query "contentType")
@@ -166,11 +186,13 @@ runs:
       run: |
         gpg --decrypt --batch --yes --passphrase "${{ inputs.envEncryptionSecret }}" -o .env .env.gpg
 
-    - name: Set outputs
+    - name: Set environmentVariables outputs on cache hit
       if: steps.cache-envs.outputs.cache-hit == 'true'
       id: get-envs-cached
       shell: bash
       run: |
+        set -euo pipefail
+
         CONTENT_TYPES="${{ inputs.contentTypes }}"
         ENV_VAR_SEP="${{ inputs.environmentVariableSeparator }}"
 
@@ -184,22 +206,70 @@ runs:
             echo "Environment variables have been added to 'environmentVariables' output"
         fi
 
-        if [[ "${CONTENT_TYPES}" == *"BuildArg"* ]]; then
-            BUILD_ARGUMENTS=$(sed ':a;N;$!ba;s/\n\([^\n]\)/ --build-arg \1/g; s/^/--build-arg /' .env)
-            echo "buildArguments=${BUILD_ARGUMENTS}" >> $GITHUB_OUTPUT
-            echo "Build arguments have been added to 'buildArguments' output"
+    - name: Retrieve build arguments on cache hit
+      if: steps.cache-envs.outputs.cache-hit == 'true' && contains(inputs.contentTypes, 'BuildArg')
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        CONTENT_TYPE="BuildArg"
+        KEYVAULT_NAME="${{ steps.kv-name.outputs.keyVaultName }}"
+
+        # Set secrets list
+        echo "Retrieving list of build arguments for key vault: ${KEYVAULT_NAME}"
+        SECRETS=()
+        SECRET_LIST=$(az keyvault secret list --vault-name "${KEYVAULT_NAME}" --query "[?contentType && contains(contentType, '${CONTENT_TYPE}')].name" --output tsv)
+        while read -r SECRET; do
+            SECRETS+=("${SECRET}")
+        done <<< "${SECRET_LIST}"
+
+        # Remove duplicates
+        SECRET_LIST=()
+        for SECRET in "${SECRETS[@]}"; do
+          # shellcheck disable=SC2076
+          if ! [[ " ${SECRET_LIST[*]} " =~ " ${SECRET} " ]]; then
+            SECRET_LIST+=("${SECRET}")
+          fi
+        done
+        SECRETS=("${SECRET_LIST[@]}")
+
+        echo "Retrieving build arguments for key vault: ${KEYVAULT_NAME}"
+        if echo "${SECRETS[*]}" | grep -E "\w" > /dev/null; then
+            for SECRET in "${SECRETS[@]}"; do
+                # Convert to upper case snake case and remove quotes
+                SECRET_NAME=$(echo "${SECRET}" | tr '[:lower:]-' '[:upper:]_' | tr "-" "_" | tr -d '"')
+
+                # Retrieve all properties of the secret
+                echo "Retrieving secret: ${SECRET_NAME}"
+
+                # Get secret value
+                SECRET_VALUE=$(az keyvault secret show --vault-name "${KEYVAULT_NAME}" -n "${SECRET}" --output tsv --query "value")
+
+                # Mask secret value in logs
+                if [[ "$SECRET_NAME" =~ (SECRET|TOKEN|KEY|PASS|CONNECTION_STRING) ]]; then
+                    echo "::add-mask::$SECRET_VALUE"
+                fi
+
+                # Get secret content type
+                SECRET_CONTENT_TYPE=$(az keyvault secret show --vault-name "${KEYVAULT_NAME}" -n "${SECRET}" --output tsv --query "contentType")
+
+                # Add secret
+                if [[ "${SECRET_CONTENT_TYPE}" == *"BuildArg"* ]]; then
+                    BUILD_ARGUMENTS="${BUILD_ARGUMENTS} ${{ inputs.buildArgPredicate }} ${SECRET_NAME}=${SECRET_VALUE}"
+                fi
+            done
         fi
+
+        echo "Build arguments have been added to 'buildArguments' output"
+        echo "buildArguments=${BUILD_ARGUMENTS}" >> $GITHUB_OUTPUT
 
     - name: Source secrets file
       if: ${{ inputs.setBuildArguments != 'true' }}
       shell: bash
       run: |
+        set -euo pipefail
+
         while read -r envVar; do
-            if [ $(echo "${envVar}" | grep -Ei "SECRET|TOKEN|KEY|PASS|CONNECTION_STRING") ]; then
-              VAR=$(echo "${envVar}" | awk -F '=' '{print $1}')
-              VALUE=$(echo $envVar | sed "s/$VAR=//g")
-              echo "::add-mask::$VALUE"
-            fi
             echo "$envVar" >> $GITHUB_ENV
         done < .env
 

--- a/action.yaml
+++ b/action.yaml
@@ -168,6 +168,7 @@ runs:
 
     - name: Set outputs
       if: steps.cache-envs.outputs.cache-hit == 'true'
+      id: get-envs
       shell: bash
       run: |
         CONTENT_TYPES="${{ inputs.contentTypes }}"

--- a/action.yaml
+++ b/action.yaml
@@ -209,17 +209,10 @@ runs:
       run: |
         gpg --symmetric --batch --yes --passphrase "${{ inputs.envEncryptionSecret }}" -o .env.gpg .env
 
-    - name: Set outputs
-      id: outputs
-      shell: bash
-      run: |
-        echo "environmentVariables=${{ steps.get-envs.outputs.environmentVariables || steps.get-envs-cached.outputs.environmentVariables }}" >> $GITHUB_OUTPUT
-        echo "buildArguments=${{ steps.get-envs.outputs.buildArguments || steps.get-envs-cached.outputs.buildArguments }}" >> $GITHUB_OUTPUT
-
 outputs:
   environmentVariables:
-    value: ${{ steps.outputs.outputs.environmentVariables }}
+    value: ${{ steps.get-envs.outputs.environmentVariables || steps.get-envs-cached.outputs.environmentVariables }}
     description: "List of environment variables retrieved from key vault"
   buildArguments:
-    value: ${{ steps.outputs.outputs.buildArguments }}
+    value: ${{ steps.get-envs.outputs.buildArguments || steps.get-envs-cached.outputs.buildArguments }}
     description: "List of build arguments retrieved from key vault"

--- a/action.yaml
+++ b/action.yaml
@@ -175,8 +175,17 @@ runs:
             echo "Build arguments have been added to 'buildArguments' output"
             echo "buildArguments=${BUILD_ARGUMENTS}" >> $GITHUB_OUTPUT
         fi
+
+        ENV_VAR_SEP="${{ inputs.environmentVariableSeparator }}"
         if [[ -z "${CONTENT_TYPES}" ]] || [[ "${CONTENT_TYPES}" == *"Env"* ]]; then
-            echo "environmentVariables=${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
+            # Set environmentVariables output to a multi-line value in case of special characters or new lines
+            if [[ "${ENV_VAR_SEP}" != " " ]]; then
+                echo 'environmentVariables<<EOF' >> $GITHUB_OUTPUT
+                echo "${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
+                echo 'EOF' >> $GITHUB_OUTPUT
+            else
+                echo "environmentVariables=${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
+            fi
             echo "Environment variables have been added to 'environmentVariables' output"
         fi
 
@@ -201,10 +210,13 @@ runs:
         if [[ -z "${CONTENT_TYPES}" ]] || [[ "${CONTENT_TYPES}" == *"Env"* ]]; then
             if [[ "${ENV_VAR_SEP}" != " " ]]; then
                 ENVIRONMENT_VARIABLES=$(sed ":a;N;\$!ba;s/\n\([^\n]\)/${ENV_VAR_SEP}\1/g" .env)
+                echo 'environmentVariables<<EOF' >> $GITHUB_OUTPUT
+                echo "${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
+                echo 'EOF' >> $GITHUB_OUTPUT
             else
                 ENVIRONMENT_VARIABLES=$(cat .env)
+                echo "environmentVariables=${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
             fi
-            echo "environmentVariables=${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
             echo "Environment variables have been added to 'environmentVariables' output"
         fi
 

--- a/action.yaml
+++ b/action.yaml
@@ -174,15 +174,12 @@ runs:
         ENV_VAR_SEP="${{ inputs.environmentVariableSeparator }}"
 
         if [[ -z "${CONTENT_TYPES}" ]] || [[ "${CONTENT_TYPES}" == *"Env"* ]]; then
-            ENVIRONMENT_VARIABLES=$(sed ':a;N;$!ba;s/\n\([^\n]\)/ \1/g' .env)
             if [[ "${ENV_VAR_SEP}" != " " ]]; then
-                echo 'environmentVariables<<EOF' >> $GITHUB_OUTPUT
-                echo "${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
-                echo 'EOF' >> $GITHUB_OUTPUT
-            else
                 ENVIRONMENT_VARIABLES=$(sed ":a;N;\$!ba;s/\n\([^\n]\)/${ENV_VAR_SEP}\1/g" .env)
-                echo "environmentVariables=${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
+            else
+                ENVIRONMENT_VARIABLES=$(cat .env)
             fi
+            echo "environmentVariables=${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
             echo "Environment variables have been added to 'environmentVariables' output"
         fi
 

--- a/action.yaml
+++ b/action.yaml
@@ -209,10 +209,17 @@ runs:
       run: |
         gpg --symmetric --batch --yes --passphrase "${{ inputs.envEncryptionSecret }}" -o .env.gpg .env
 
+    - name: Set outputs
+      id: outputs
+      shell: bash
+      run: |
+        echo "environmentVariables=${{ steps.get-envs.outputs.environmentVariables || steps.get-envs-cached.outputs.environmentVariables }}" >> $GITHUB_OUTPUT
+        echo "buildArguments=${{ steps.get-envs.outputs.buildArguments || steps.get-envs-cached.outputs.buildArguments }}" >> $GITHUB_OUTPUT
+
 outputs:
   environmentVariables:
-    value: ${{ steps.get-envs.outputs.environmentVariables || steps.get-envs-cached.outputs.environmentVariables }}
+    value: ${{ steps.outputs.outputs.environmentVariables }}
     description: "List of environment variables retrieved from key vault"
   buildArguments:
-    value: ${{ steps.get-envs.outputs.buildArguments || steps.get-envs-cached.outputs.buildArguments }}
+    value: ${{ steps.outputs.outputs.buildArguments }}
     description: "List of build arguments retrieved from key vault"

--- a/action.yaml
+++ b/action.yaml
@@ -62,6 +62,7 @@ runs:
       id: kv-name
       shell: bash
       run: |
+        # Retrieve key vault name
         set -euo pipefail
 
         REPOSITORY_NAME="${{ inputs.repositoryName }}"
@@ -82,6 +83,7 @@ runs:
       if: steps.cache-envs.outputs.cache-hit != 'true' || (steps.cache-envs.outputs.cache-hit == 'true' && contains(inputs.contentTypes, 'BuildArg'))
       shell: bash
       run: |
+        # Check if key vault exists
         set -euo pipefail
 
         KEYVAULT_NAME="${{ steps.kv-name.outputs.keyVaultName || inputs.environmentKeyVault }}"
@@ -102,6 +104,7 @@ runs:
       id: get-envs
       shell: bash
       run: |
+        # Pull secrets from Key Vault
         set -euo pipefail
 
         CONTENT_TYPES="${{ inputs.contentTypes }}"
@@ -173,13 +176,7 @@ runs:
             echo "buildArguments=${BUILD_ARGUMENTS}" >> $GITHUB_OUTPUT
         fi
         if [[ -z "${CONTENT_TYPES}" ]] || [[ "${CONTENT_TYPES}" == *"Env"* ]]; then
-            if [[ "${{ inputs.environmentVariableSeparator }}" != " " ]]; then
-                echo 'environmentVariables<<EOF' >> $GITHUB_OUTPUT
-                echo "${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
-                echo 'EOF' >> $GITHUB_OUTPUT
-            else
-                echo "environmentVariables=${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
-            fi
+            echo "environmentVariables=${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
             echo "Environment variables have been added to 'environmentVariables' output"
         fi
 
@@ -187,6 +184,7 @@ runs:
       if: steps.cache-envs.outputs.cache-hit == 'true'
       shell: sh
       run: |
+        # Decrypt cached .env file
         gpg --decrypt --batch --yes --passphrase "${{ inputs.envEncryptionSecret }}" -o .env .env.gpg
 
     - name: Set environmentVariables outputs on cache hit
@@ -194,6 +192,7 @@ runs:
       id: get-envs-cached
       shell: bash
       run: |
+        # Set environmentVariables outputs on cache hit
         set -euo pipefail
 
         CONTENT_TYPES="${{ inputs.contentTypes }}"
@@ -211,8 +210,10 @@ runs:
 
     - name: Retrieve build arguments on cache hit
       if: steps.cache-envs.outputs.cache-hit == 'true' && contains(inputs.contentTypes, 'BuildArg')
+      id: get-build-args-cached
       shell: bash
       run: |
+        # Retrieve build arguments on cache hit
         set -euo pipefail
 
         CONTENT_TYPE="BuildArg"
@@ -272,6 +273,7 @@ runs:
       if: ${{ inputs.setBuildArguments != 'true' }}
       shell: bash
       run: |
+        # Source secrets file
         set -euo pipefail
 
         while read -r envVar; do
@@ -282,6 +284,7 @@ runs:
       if: steps.cache-envs.outputs.cache-hit != 'true'
       shell: sh
       run: |
+        # Encrypt .env file for caching
         gpg --symmetric --batch --yes --passphrase "${{ inputs.envEncryptionSecret }}" -o .env.gpg .env
 
 outputs:
@@ -289,5 +292,5 @@ outputs:
     value: ${{ steps.get-envs.outputs.environmentVariables || steps.get-envs-cached.outputs.environmentVariables }}
     description: "List of environment variables retrieved from key vault"
   buildArguments:
-    value: ${{ steps.get-envs.outputs.buildArguments || steps.get-envs-cached.outputs.buildArguments }}
+    value: ${{ steps.get-envs.outputs.buildArguments || steps.get-build-args-cached.outputs.buildArguments }}
     description: "List of build arguments retrieved from key vault"

--- a/action.yaml
+++ b/action.yaml
@@ -168,7 +168,7 @@ runs:
 
     - name: Set outputs
       if: steps.cache-envs.outputs.cache-hit == 'true'
-      id: get-envs
+      id: get-envs-cached
       shell: bash
       run: |
         CONTENT_TYPES="${{ inputs.contentTypes }}"
@@ -211,8 +211,8 @@ runs:
 
 outputs:
   environmentVariables:
-    value: ${{ steps.get-envs.outputs.environmentVariables }}
+    value: ${{ steps.get-envs.outputs.environmentVariables || steps.get-envs-cached.outputs.environmentVariables }}
     description: "List of environment variables retrieved from key vault"
   buildArguments:
-    value: ${{ steps.get-envs.outputs.buildArguments }}
+    value: ${{ steps.get-envs.outputs.buildArguments || steps.get-envs-cached.outputs.buildArguments }}
     description: "List of build arguments retrieved from key vault"

--- a/action.yaml
+++ b/action.yaml
@@ -173,17 +173,19 @@ runs:
       run: |
         CONTENT_TYPES="${{ inputs.contentTypes }}"
         ENV_VAR_SEP="${{ inputs.environmentVariableSeparator }}"
+
         if [[ -z "${CONTENT_TYPES}" ]] || [[ "${CONTENT_TYPES}" == *"Env"* ]]; then
             if [[ "${ENV_VAR_SEP}" != " " ]]; then
                 echo 'environmentVariables<<EOF' >> $GITHUB_OUTPUT
                 sed ':a;N;$!ba;s/\n\([^\n]\)/ \1/g' .env >> $GITHUB_OUTPUT
                 echo -e '\nEOF' >> $GITHUB_OUTPUT
             else
-                ENVIRONMENT_VARIABLES=$(sed ':a;N;$!ba;s/\n\([^\n]\)/${ENV_VAR_SEP}\1/g' .env")
+                ENVIRONMENT_VARIABLES=$(sed ":a;N;\$!ba;s/\n\([^\n]\)/${ENV_VAR_SEP}\1/g" .env)
                 echo "environmentVariables=${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
             fi
             echo "Environment variables have been added to 'environmentVariables' output"
         fi
+
         if [[ "${CONTENT_TYPES}" == *"BuildArg"* ]]; then
             BUILD_ARGUMENTS=$(sed ':a;N;$!ba;s/\n\([^\n]\)/ --build-arg \1/g; s/^/--build-arg /' .env)
             echo "buildArguments=${BUILD_ARGUMENTS}" >> $GITHUB_OUTPUT

--- a/action.yaml
+++ b/action.yaml
@@ -222,7 +222,7 @@ runs:
 
         if [[ -z "${CONTENT_TYPES}" ]] || [[ "${CONTENT_TYPES}" == *"Env"* ]]; then
             if [[ "${ENV_VAR_SEP}" != " " ]]; then
-                ENVIRONMENT_VARIABLES=$(sed ":a;N;\$!ba;s/\n\([^\n]\)/${ENV_VAR_SEP}\1/g" .env)
+                ENVIRONMENT_VARIABLES=$(sed ":a;N;\$!ba;s|\n\([^\n]\)|${ENV_VAR_SEP}\1|g" .env)
                 echo 'environmentVariables<<EOF' >> $GITHUB_OUTPUT
                 echo "${ENVIRONMENT_VARIABLES}" >> $GITHUB_OUTPUT
                 echo 'EOF' >> $GITHUB_OUTPUT

--- a/action.yaml
+++ b/action.yaml
@@ -169,7 +169,7 @@ runs:
 
     - name: Set outputs
       if: steps.cache-envs.outputs.cache-hit == 'true'
-      shell: sh
+      shell: bash
       run: |
         CONTENT_TYPES="${{ inputs.contentTypes }}"
         ENV_VAR_SEP="${{ inputs.environmentVariableSeparator }}"
@@ -192,7 +192,7 @@ runs:
 
     - name: Source secrets file
       if: ${{ inputs.setBuildArguments != 'true' }}
-      shell: sh
+      shell: bash
       run: |
         while read -r envVar; do
             if [ $(echo "${envVar}" | grep -Ei "SECRET|TOKEN|KEY|PASS|CONNECTION_STRING") ]; then

--- a/action.yaml
+++ b/action.yaml
@@ -58,7 +58,7 @@ runs:
         creds: "${{ inputs.azurecredentials }}"
 
     - name: Retrieve key vault name
-      if: inputs.environmentKeyVault != '' && (steps.cache-envs.outputs.cache-hit != 'true' || (steps.cache-envs.outputs.cache-hit == 'true' && contains(inputs.contentTypes, 'BuildArg')))
+      if: ! inputs.environmentKeyVault && (steps.cache-envs.outputs.cache-hit != 'true' || (steps.cache-envs.outputs.cache-hit == 'true' && contains(inputs.contentTypes, 'BuildArg')))
       id: kv-name
       shell: bash
       run: |


### PR DESCRIPTION
<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-733" title="DEVOPS-733" target="_blank">DEVOPS-733</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Research: Improve Playwright tests run time</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Research" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10501?size=medium" />
        Research
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

This action can take up to 1min to 1min30s depending on the amount of secrets being pulled and with how long the Azure login step takes. I wanted to cut down on the runtime to speed up the CI tests for the GoComics UI app as well as any other workflow that uses the `get-envs` action multiple times on the same commit. 

- Enable caching when retrieving environment variables
  - Added `actions/cache@v4` for caching the encrypted `.env` file.
    - If there is a cached `.env` file, pull it down and decrypt it. Then, read all the environment variables into `$GITHUB_ENV`. If the `contentTypes` input contains `BuildArg`, then proceed with pulling down the related secrets from Azure (since the Content Type of the each env var/secret is not stored in the `.env` file.
    - If there isn't a cached `.env` file, pull down the secrets as usual and source them to `$GITHUB_ENV`. Then, encrypt the `.env` file using the `ENV_ENCRYPTION_SECRET` organization secret.
- Other QOL updates:
  - Add step for "Retrieve key vault name" and "Check if key vault exists" to avoid redundant calls to Azure. 
  - Mask confidential secrets as soon as they're pulled down from Azure
  - Added comments that contained the name of each step at the top of each script so that it's easier to tell what step is being run

### Test run 1 (cached)
Inputs:
```
azurecredentials: ${{ secrets.AZURE_CREDENTIALS }}
environment: production
contentTypes: BuildArg Env
envEncryptionSecret: ${{ secrets.ENV_ENCRYPTION_SECRET }}
```
<img width="634" height="860" alt="image" src="https://github.com/user-attachments/assets/50b1a477-42f0-4828-8ae5-73bbb147fc81" />

### Test run 2 (no cache, only envs)
Inputs:
```
azurecredentials: ${{ secrets.AZURE_CREDENTIALS }}
environment: production
contentTypes: Env
envEncryptionSecret: ${{ secrets.ENV_ENCRYPTION_SECRET }}
environmentVariableSeparator: "_separator_"
```
<img width="624" height="673" alt="image" src="https://github.com/user-attachments/assets/342202c1-20a1-443c-a4a4-feebceeaa054" />

### Test run 3 (cached, specifying key vault name directory, new line separator)
Inputs:
```
azurecredentials: ${{ secrets.AZURE_CREDENTIALS }}
contentTypes: Env
envEncryptionSecret: ${{ secrets.ENV_ENCRYPTION_SECRET }}
environmentKeyVault: "test-wkflw-production"
environmentVariableSeparator: "\n"
```

<img width="642" height="478" alt="image" src="https://github.com/user-attachments/assets/b0456e52-316f-473e-867c-ea467eb7854d" />


## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-733
