### PR TITLE
[DEVOPS-792] Fix Key Vault resolution failing if Key Vault prefix is not set

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -57,8 +57,33 @@ runs:
       with:
         creds: "${{ inputs.azurecredentials }}"
 
-    - name: Retrieve key vault name
+    - name: Check key vault name input
       if: (!inputs.environmentKeyVault) && (steps.cache-envs.outputs.cache-hit != 'true' || (steps.cache-envs.outputs.cache-hit == 'true' && contains(inputs.contentTypes, 'BuildArg')))
+      id: check-kv-input
+      shell: bash
+      run: |
+        # Check key vault name input
+        set -euo pipefail
+
+        KEYVAULT_NAME="${{ inputs.environmentKeyVault }}"
+        ENVIRONMENT="${{ inputs.environment }}"
+
+        if [[ "${ENVIRONMENT}" == "" ]] && [[ "${KEYVAULT_NAME}" = "-${ENVIRONMENT}" ]]; then
+            echo "::warning::The 'environmentKeyVault' input appears to be incorrectly set. If you intend to auto-discover the Key Vault based on tags, please leave this input blank. If you wish to specify a Key Vault name directly, please provide the correct name."
+            echo "::error::Environment input is required when 'environmentKeyVault' is not provided."
+            exit 1
+        fi
+
+        if [[ -n "${KEYVAULT_NAME}" ]] && [[ "${KEYVAULT_NAME}" != "-${ENVIRONMENT}" ]]; then
+            echo "::warning::The 'environmentKeyVault' input appears to be incorrectly set. If you intend to auto-discover the Key Vault based on tags, please leave this input blank. If you wish to specify a Key Vault name directly, please provide the correct name."
+            echo "::warning::Defaulting to auto-discovery of Key Vault based on tags."
+            echo "keyVaultName=" >> $GITHUB_OUTPUT
+        else
+            echo "keyVaultName=${KEYVAULT_NAME}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Retrieve key vault name
+      if: (steps.check-kv-input.outputs.keyVaultName != '') && (steps.cache-envs.outputs.cache-hit != 'true' || (steps.cache-envs.outputs.cache-hit == 'true' && contains(inputs.contentTypes, 'BuildArg')))
       id: kv-name
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -74,7 +74,7 @@ runs:
             exit 1
         fi
 
-        if [[ -n "${KEYVAULT_NAME}" ]] && [[ "${KEYVAULT_NAME}" != "-${ENVIRONMENT}" ]]; then
+        if [[ "${KEYVAULT_NAME}" = "-${ENVIRONMENT}" ]]; then
             echo "::warning::The 'environmentKeyVault' input appears to be incorrectly set. If you intend to auto-discover the Key Vault based on tags, please leave this input blank. If you wish to specify a Key Vault name directly, please provide the correct name."
             echo "::warning::Defaulting to auto-discovery of Key Vault based on tags."
             echo "keyVaultName=" >> $GITHUB_OUTPUT


### PR DESCRIPTION

<details open>
  <summary><a href="https://amuniversal.atlassian.net/browse/DEVOPS-792" title="DEVOPS-792" target="_blank">DEVOPS-792</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>get-envs step fails on not finding a keyvault even though environment is passed as input</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://amuniversal.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break action-jira-linter's functionality.
  added_by_jira_lint
-->
---

…'t set

<!-- Please make sure you read the contribution guidelines and then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  [JIRA-XXX]: <description>
-->

## Description

- Fix Key Vault resolution failing if Key Vault prefix is not set

## Related Links

<!-- List any links related to this pull request here

Replace "JIRA-XXX" with the your Jira issue key -->

- Jira Issue: DEVOPS-792
